### PR TITLE
Release 0.3.3.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for elm-syntax
 
+## 0.3.3.0
+
+- Add support for GHC up to 9.6
+
 ## 0.3.2.0
 
 - The `Monad` instance for `Expression` has been redefined, leading to considerably faster performance. (see [#4](https://github.com/haskell-to-elm/elm-syntax/pull/4))

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                elm-syntax
-version:             0.3.2.0
+version:             0.3.3.0
 github:              "haskell-to-elm/elm-syntax"
 license:             BSD3
 author:              "Olle Fredriksson"


### PR DESCRIPTION
It doesn't seem like there is anything stopping a release to enable later versions of GHC (and unlocking later versions of GHC for downstream dependencies such as `haskell-to-elm`).

If after a week there are no objections, I'll go ahead and merge and tag, but I won't be able to upload to hackage as I'm not on the `elm-syntax` maintainer list there.